### PR TITLE
Switch to static RegEx method calls

### DIFF
--- a/Functions/Hash.cs
+++ b/Functions/Hash.cs
@@ -35,8 +35,7 @@ namespace Functions
         return false;
       }
 
-      var regex = new Regex(@"\b([a-fA-F0-9]{40})\b");
-      var match = regex.Match(input);
+      var match = Regex.Match(input, @"\b([a-fA-F0-9]{40})\b");
       return match.Length > 0;
     }
   }

--- a/Functions/Range.cs
+++ b/Functions/Range.cs
@@ -22,8 +22,7 @@ namespace Functions
         return PwnedResponse.CreateResponse(req, HttpStatusCode.BadRequest, "Missing hash prefix");
       }
 
-      var querystringRegex = new Regex("^[a-fA-F0-9]{5}$");
-      var match = querystringRegex.Match(hashPrefix);
+      var match = Regex.Match(hashPrefix, "^[a-fA-F0-9]{5}$");
       if (match.Length == 0)
       {
         return PwnedResponse.CreateResponse(req, HttpStatusCode.BadRequest, "The hash prefix was not in a valid format");


### PR DESCRIPTION
This PR switches the `RegEx` instances to use the `static` variants instead.

Each time a `new RegEx()` is created, it has to **"compile"** the pattern to an intermediate format. If you use the static version, it still has to do that once, but it has an internal cache in which it stores those compiled regular expressions, making subsequent calls (a lot) faster.

The amount of regular expressions in this project is well below `Regex.CacheSize`, so we shouldn't see any churn there and get the full benefit of the cache.

More info: <https://docs.microsoft.com/en-us/dotnet/standard/base-types/compilation-and-reuse-in-regular-expressions>

As a follow up it would be interesting to also add the `RegexOptions.Compiled` flag, which increases the time and effort it takes for the first call, but should make subsequent calls faster. I don't know if the trade-of is worth it within an Azure Function though, so that would require some benchmarking.