### PR TITLE
Improving performance for hash prefix validation.

### DIFF
--- a/Functions/Range.cs
+++ b/Functions/Range.cs
@@ -13,25 +13,46 @@ namespace Functions
     public static HttpResponseMessage RunRoute([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "range/{hashPrefix}")] HttpRequestMessage req, string hashPrefix, TraceWriter log)
     {
       return GetData(req, hashPrefix, log);
+        }
+
+        private static HttpResponseMessage GetData(HttpRequestMessage req, string hashPrefix, TraceWriter log)
+        {
+            if (string.IsNullOrEmpty(hashPrefix))
+            {
+                return PwnedResponse.CreateResponse(req, HttpStatusCode.BadRequest, "Missing hash prefix");
+            }
+
+            if(!IsValidPrefix(hashPrefix))
+            {
+                return PwnedResponse.CreateResponse(req, HttpStatusCode.BadRequest, "The hash prefix was not in a valid format");
+            }
+
+            var stream = new BlobStorage(log).GetByHashesByPrefix(hashPrefix.ToUpper(), out var lastModified);
+            var response = PwnedResponse.CreateResponse(req, HttpStatusCode.OK, null, stream, lastModified);
+            return response;
+        }
+
+        private static bool IsValidPrefix(string hashPrefix)
+        {
+            if (hashPrefix.Length != 5)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < 5; i++)
+            {
+                if (!IsHex(hashPrefix[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsHex(char x)
+        {
+            return (x >= '0' && x <= '9') || (x >= 'a' && x <= 'f') || (x >= 'A' && x <= 'F');
+        }
     }
-
-    private static HttpResponseMessage GetData(HttpRequestMessage req, string hashPrefix, TraceWriter log)
-    {
-      if (string.IsNullOrEmpty(hashPrefix))
-      {
-        return PwnedResponse.CreateResponse(req, HttpStatusCode.BadRequest, "Missing hash prefix");
-      }
-
-      var querystringRegex = new Regex("^[a-fA-F0-9]{5}$");
-      var match = querystringRegex.Match(hashPrefix);
-      if (match.Length == 0)
-      {
-        return PwnedResponse.CreateResponse(req, HttpStatusCode.BadRequest, "The hash prefix was not in a valid format");
-      }
-
-      var stream = new BlobStorage(log).GetByHashesByPrefix(hashPrefix.ToUpper(), out var lastModified);
-      var response = PwnedResponse.CreateResponse(req, HttpStatusCode.OK, null, stream, lastModified);
-      return response;
-    }
-  }
 }

--- a/Functions/Range.cs
+++ b/Functions/Range.cs
@@ -13,46 +13,46 @@ namespace Functions
     public static HttpResponseMessage RunRoute([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "range/{hashPrefix}")] HttpRequestMessage req, string hashPrefix, TraceWriter log)
     {
       return GetData(req, hashPrefix, log);
-        }
-
-        private static HttpResponseMessage GetData(HttpRequestMessage req, string hashPrefix, TraceWriter log)
-        {
-            if (string.IsNullOrEmpty(hashPrefix))
-            {
-                return PwnedResponse.CreateResponse(req, HttpStatusCode.BadRequest, "Missing hash prefix");
-            }
-
-            if(!IsValidPrefix(hashPrefix))
-            {
-                return PwnedResponse.CreateResponse(req, HttpStatusCode.BadRequest, "The hash prefix was not in a valid format");
-            }
-
-            var stream = new BlobStorage(log).GetByHashesByPrefix(hashPrefix.ToUpper(), out var lastModified);
-            var response = PwnedResponse.CreateResponse(req, HttpStatusCode.OK, null, stream, lastModified);
-            return response;
-        }
-
-        private static bool IsValidPrefix(string hashPrefix)
-        {
-            if (hashPrefix.Length != 5)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < 5; i++)
-            {
-                if (!IsHex(hashPrefix[i]))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        private static bool IsHex(char x)
-        {
-            return (x >= '0' && x <= '9') || (x >= 'a' && x <= 'f') || (x >= 'A' && x <= 'F');
-        }
     }
+    
+    private static HttpResponseMessage GetData(HttpRequestMessage req, string hashPrefix, TraceWriter log)
+    {
+      if (string.IsNullOrEmpty(hashPrefix))
+      {
+        return PwnedResponse.CreateResponse(req, HttpStatusCode.BadRequest, "Missing hash prefix");
+      }
+      
+      if (!IsValidPrefix(hashPrefix))
+      {
+        return PwnedResponse.CreateResponse(req, HttpStatusCode.BadRequest, "The hash prefix was not in a valid format");
+      }
+      
+      var stream = new BlobStorage(log).GetByHashesByPrefix(hashPrefix.ToUpper(), out var lastModified);
+      var response = PwnedResponse.CreateResponse(req, HttpStatusCode.OK, null, stream, lastModified);
+      return response;
+    }
+    
+    private static bool IsValidPrefix(string hashPrefix)
+    {
+      if (hashPrefix.Length != 5)
+      {
+        return false;
+      }
+      
+      for (int i = 0; i < 5; i++)
+      {
+        if (!IsHex(hashPrefix[i]))
+        {
+          return false;
+        }
+      }
+      
+      return true;
+    }
+    
+    private static bool IsHex(char x)
+    {
+      return (x >= '0' && x <= '9') || (x >= 'a' && x <= 'f') || (x >= 'A' && x <= 'F');
+    }
+  }
 }

--- a/Functions/Range.cs
+++ b/Functions/Range.cs
@@ -34,6 +34,8 @@ namespace Functions
     
     private static bool IsValidPrefix(string hashPrefix)
     {
+      bool IsHex(char x) => (x >= '0' && x <= '9') || (x >= 'a' && x <= 'f') || (x >= 'A' && x <= 'F');
+
       if (hashPrefix.Length != 5)
       {
         return false;
@@ -48,11 +50,6 @@ namespace Functions
       }
       
       return true;
-    }
-    
-    private static bool IsHex(char x)
-    {
-      return (x >= '0' && x <= '9') || (x >= 'a' && x <= 'f') || (x >= 'A' && x <= 'F');
     }
   }
 }


### PR DESCRIPTION
The earlier version which creates a new RegEx every time to match the hash prefix allocates heavily over time and uses a lot of unnecessary CPU.

This method which does a simple length check + checks for valid characters in the prefix does no allocation and is around 200 - 500 times faster than the RegEx method 😇

Results from BenchmarkDotNet:
```ini
BenchmarkDotNet=v0.13.0, OS=Windows 10.0.21390
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4395.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.4395.0), X64 RyuJIT
```
| Method | input |          Mean |      Error |     StdDev | Ratio |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------- |------ |--------------:|-----------:|-----------:|------:|-------:|-------:|------:|----------:|
| Before |       | 1,934.1493 ns | 24.0141 ns | 21.2879 ns | 1.000 | 0.8125 | 0.0038 |     - |   5,127 B |
|  After |       |     0.7003 ns |  0.0107 ns |  0.0095 ns | 0.000 |      - |      - |     - |         - |
|        |       |               |            |            |       |        |        |       |           |
| Before | ABCDE | 2,034.3451 ns | 12.2026 ns | 10.1897 ns | 1.000 | 0.8125 | 0.0038 |     - |   5,127 B |
|  After | ABCDE |    11.4591 ns |  0.0690 ns |  0.0645 ns | 0.006 |      - |      - |     - |         - |
|        |       |               |            |            |       |        |        |       |           |
| Before | OHNO! | 1,979.7217 ns |  9.5690 ns |  8.4827 ns | 1.000 | 0.8125 | 0.0038 |     - |   5,127 B |
|  After | OHNO! |     3.3881 ns |  0.0327 ns |  0.0306 ns | 0.002 |      - |      - |     - |         - |

Benchmark code:
```csharp
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

using System.Collections.Generic;
using System.Text.RegularExpressions;

namespace Benchmarks
{
    class Program
    {
        static void Main(string[] args)
        {
            BenchmarkRunner.Run<HashBenchmark>();
        }
    }

    [MemoryDiagnoser]
    public class HashBenchmark
    {
        public IEnumerable<string> Inputs()
        {
            yield return "";
            yield return "OHNO!";
            yield return "ABCDE";
        }

        [ArgumentsSource("Inputs")]
        [Benchmark(Baseline = true)]
        public bool Before(string input)
        {
            var querystringRegex = new Regex("^[a-fA-F0-9]{5}$");
            var match = querystringRegex.Match(input);
            if (match.Length == 0)
            {
                return false;
            }

            return true;
        }

        [ArgumentsSource("Inputs")]
        [Benchmark]
        public bool After(string input)
        {
            return IsValidPrefix(input);
        }

        private static bool IsValidPrefix(string hashPrefix)
        {
            bool IsHex(char x)
            {
                return (x >= '0' && x <= '9') || (x >= 'a' && x <= 'f') || (x >= 'A' && x <= 'F');
            }

            if (hashPrefix.Length != 5)
            {
                return false;
            }

            for (int i = 0; i < 5; i++)
            {
                if (!IsHex(hashPrefix[i]))
                {
                    return false;
                }
            }

            return true;
        }
    }
}
```