### PR TITLE
Correct README.md link to CODE_OF_CONDUCT.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](code_of_conduct.md) 
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](CODE_OF_CONDUCT.md) 
 
 # PwnedPasswordsAzureFunction
 APIs for the k-anonymity Pwned Passwords implementation


### PR DESCRIPTION
Having the link point to lower case code_of_conduct.md returns a 404-error as github is case sensitive 

https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/code_of_conduct.md
vs
https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/CODE_OF_CONDUCT.md