### PR TITLE
Switch to static RegEx method calls

### DIFF
--- a/Functions/Hash.cs
+++ b/Functions/Hash.cs
@@ -35,8 +35,7 @@ namespace Functions
         return false;
       }
 
-      var regex = new Regex(@"\b([a-fA-F0-9]{40})\b");
-      var match = regex.Match(input);
+      var match = Regex.Match(input, @"\b([a-fA-F0-9]{40})\b");
       return match.Length > 0;
     }
   }


### PR DESCRIPTION
This is a follow up to #9, which was closed because it was supposedly superseded by #10, but that PR only removed the Regex from `Range.cs`, not the one from `Hash.cs`. 

This is a rebase with only the `Hash.cs` from my previous PR.