### PR TITLE
Tests and performance fixes for hash helpers.

### DIFF
--- a/Functions/Hash.cs
+++ b/Functions/Hash.cs
@@ -1,6 +1,6 @@
-﻿using System.Security.Cryptography;
+﻿using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Text;
-using System.Text.RegularExpressions;
 
 namespace Functions
 {
@@ -9,32 +9,41 @@ namespace Functions
     /// </summary>
     public static class Hash
     {
+        private static readonly char[] HexChars = new[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+        private static readonly SHA1 Hasher = new SHA1Managed();
+        private static readonly object HashLock = new object();
+
         /// <summary>
         /// Create a SHA-1 hash
         /// </summary>
         /// <param name="input"></param>
         /// <param name="source">Source encoding. Defaults to UTF-8. Pass in any other value for Unicode</param>
         /// <returns>The input string as a SHA-1 hash</returns>
-        public static string CreateSHA1Hash(string input, string source = "UTF8")
+        public static string CreateSHA1Hash(this string input, string source = "UTF8")
         {
             if (input == null)
             {
                 return null;
             }
 
-            using (var sha1 = new SHA1Managed())
+            var bytes = source == "UTF8" ? Encoding.UTF8.GetBytes(input) : Encoding.Unicode.GetBytes(input);
+            byte[] hash;
+            
+            // SHA1.ComputeHash is not thread safe, so let's lock. It's still quicker than creating a new instance each time.
+            lock (HashLock)
             {
-                var bytes = source == "UTF8" ? Encoding.UTF8.GetBytes(input) : Encoding.Unicode.GetBytes(input);
-                var hash = sha1.ComputeHash(bytes);
-                var sb = new StringBuilder(hash.Length * 2);
-
-                foreach (var b in hash)
-                {
-                    sb.Append(b.ToString("X2"));
-                }
-
-                return sb.ToString().ToUpper();
+                hash = Hasher.ComputeHash(bytes);
             }
+
+            var hexChars = new char[hash.Length * 2];
+            int index = 0;
+            for (int i = 0; i < hash.Length; i++)
+            {
+                hexChars[index++] = HexChars[(hash[i] >> 4) & 0b1111];
+                hexChars[index++] = HexChars[(hash[i]) & 0b1111];
+            }
+
+            return new string(hexChars);
         }
 
         /// <summary>
@@ -42,15 +51,27 @@ namespace Functions
         /// </summary>
         /// <param name="input">Input hash to check</param>
         /// <returns>Boolean representing if the input is valid or not</returns>
-        public static bool IsStringSHA1Hash(string input)
+        public static bool IsStringSHA1Hash(this string input) => input.IsHexStringOfLength(40);
+        
+        public static bool IsHexStringOfLength(this string input, int requiredLength)
         {
-            if (string.IsNullOrWhiteSpace(input))
+            if (string.IsNullOrWhiteSpace(input) || input?.Length != requiredLength)
             {
                 return false;
             }
 
-            var match = Regex.Match(input, @"\b([a-fA-F0-9]{40})\b");
-            return match.Length > 0;
+            for (int i = 0; i < requiredLength; i++)
+            {
+                if (!input[i].IsHex())
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsHex(this char x) => (x >= '0' && x <= '9') || (x >= 'a' && x <= 'f') || (x >= 'A' && x <= 'F');
     }
 }

--- a/Functions/Range.cs
+++ b/Functions/Range.cs
@@ -38,7 +38,7 @@ namespace Functions
                 return PwnedResponse.CreateResponse(req, HttpStatusCode.BadRequest, "Missing hash prefix");
             }
 
-            if (!IsValidPrefix(hashPrefix))
+            if (!hashPrefix.IsHexStringOfLength(5))
             {
                 return PwnedResponse.CreateResponse(req, HttpStatusCode.BadRequest, "The hash prefix was not in a valid format");
             }
@@ -47,26 +47,6 @@ namespace Functions
             var stream = storage.GetByHashesByPrefix(hashPrefix.ToUpper(), out var lastModified);
             var response = PwnedResponse.CreateResponse(req, HttpStatusCode.OK, null, stream, lastModified);
             return response;
-        }
-
-        private static bool IsValidPrefix(string hashPrefix)
-        {
-            bool IsHex(char x) => (x >= '0' && x <= '9') || (x >= 'a' && x <= 'f') || (x >= 'A' && x <= 'F');
-
-            if (hashPrefix.Length != 5)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < 5; i++)
-            {
-                if (!IsHex(hashPrefix[i]))
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
     }
 }

--- a/PwnedPasswords.sln
+++ b/PwnedPasswords.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{E7E72F74-A4A4-4D3F-8F97-703FA172647C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +22,10 @@ Global
 		{ED82AA3F-3700-4C81-8393-89270437C908}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED82AA3F-3700-4C81-8393-89270437C908}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ED82AA3F-3700-4C81-8393-89270437C908}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7E72F74-A4A4-4D3F-8F97-703FA172647C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7E72F74-A4A4-4D3F-8F97-703FA172647C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7E72F74-A4A4-4D3F-8F97-703FA172647C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7E72F74-A4A4-4D3F-8F97-703FA172647C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/HashTests.cs
+++ b/Tests/HashTests.cs
@@ -1,0 +1,56 @@
+﻿using Functions;
+
+using Xunit;
+
+namespace Tests
+{
+    public class HashTests
+    {
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("123", true)]
+        [InlineData("OHNO!", false)]
+        [InlineData("0BADF00D", true)]
+        [InlineData("0bAdF00D", true)]
+        public void IsHexString(string input, bool isHex)
+        {
+            Assert.Equal(isHex, input.IsHexStringOfLength(input?.Length ?? 0));
+        }
+
+        [Theory]
+        [InlineData("Passw0rd!", "F4A69973E7B0BF9D160F9F60E3C3ACD2494BEB0D")]
+        [InlineData("hunter2", "F3BBBD66A63D4BF1747940578EC3D0103530E21D")]
+        public void CreateSHA1Hash(string input, string expected)
+        {
+            Assert.Equal(expected, Hash.CreateSHA1Hash(input));
+        }
+
+        [Theory]
+        [InlineData(null, 0, false)]
+        [InlineData("", 0, false)]
+        [InlineData("01", 2, true)]
+        [InlineData("aB", 2, true)]
+        [InlineData("F4A69973E7B0BF9D160F9F60E3C3ACD2494BEB0D", 40, true)]
+        [InlineData("F4A69973E7B0BF9D160F9F60E3C3ACD2494BEB0D", 39, false)]
+        [InlineData("F4A69", 5, true)]
+        public void IsHexStringOfLength(string input, int length, bool expected)
+        {
+            Assert.Equal(expected, input.IsHexStringOfLength(length));
+        }
+
+        [Theory]
+        [InlineData("F4A69973E7B0BF9D160F9F60E3C3ACD2494BEB0D", true)]
+        [InlineData("F3BBBD66A63D4BF1747940578EC3D0103530E21D", true)]
+        [InlineData("f4A69973E7B0BF9D160f9f60E3C3ACD2494BEB0D", true)]
+        [InlineData("f3bbBD66A63D4BF1747940578EC3D0103530E21D", true)]
+        [InlineData("G3BBBD66A63D4BF1747940578EC3D0103530E21D", false)]
+        [InlineData("F3BBBD66A63D4BF1747940578EC3D0103530E21DAA", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void IsSHA1Hash(string input, bool expected)
+        {
+            Assert.Equal(expected, Hash.IsStringSHA1Hash(input));
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Functions\Functions.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR has the following changes:
* Improved performance and reduced allocations for SHA1 hash helpers 🚀
  * `IsStringSHA1Hash` is now hundreds of times faster and doesn't allocate any memory except for the empty string case which is almost a nanosecond slower now 😱
  * `CreateSHA1Hash` is now around 3 times faster and allocates 4 times less than previously. It can also be improved even more once the project moves to .NET Core so stay tuned :)
* SHA1 hash helpers are now extensions methods
* Added unit tests for SHA1 hash helpers

```ini
BenchmarkDotNet=v0.13.0, OS=Windows 10.0.21390
Intel Core i7-10700 CPU 2.90GHz, 1 CPU, 16 logical and 8 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4395.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.4395.0), X64 RyuJIT
```

|              Type | Method |           Input |         Mean |      Error |     StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |------- |---------------- |-------------:|-----------:|-----------:|------:|--------:|-------:|------:|------:|----------:|
|  IsStringSHA1Hash | Before |                 |     2.091 ns |  0.0243 ns |  0.0215 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|  IsStringSHA1Hash |  After |                 |     2.872 ns |  0.0205 ns |  0.0182 ns |  1.37 |    0.02 |      - |     - |     - |         - |
|  IsStringSHA1Hash | Before | SCOTTHELMESUCKS |   918.974 ns |  5.2620 ns |  4.3940 ns | 1.000 |    0.00 | 0.0553 |     - |     - |     353 B |
|  IsStringSHA1Hash |  After | SCOTTHELMESUCKS |     3.807 ns |  0.0334 ns |  0.0313 ns | 0.004 |    0.00 |      - |     - |     - |         - |
|  IsStringSHA1Hash | Before |           F4A69 |   940.215 ns | 10.0856 ns |  9.4341 ns | 1.000 |    0.00 | 0.0553 |     - |     - |     353 B |
|  IsStringSHA1Hash |  After |           F4A69 |     3.791 ns |  0.0349 ns |  0.0326 ns | 0.004 |    0.00 |      - |     - |     - |         - |
|                   |        |                 |              |            |            |       |         |        |       |       |           |
|    CreateSHA1Hash | Before |       Passw0rd1 | 1,618.698 ns | 13.5409 ns | 12.0037 ns |  1.00 |    0.00 | 0.2842 |     - |     - |   1,797 B |
|    CreateSHA1Hash |  After |       Passw0rd1 |   532.415 ns |  3.1252 ns |  2.6097 ns |  0.33 |    0.00 | 0.0677 |     - |     - |     433 B |
|    CreateSHA1Hash | Before |         hunter2 | 1,617.232 ns | 14.0797 ns | 13.1701 ns |  1.00 |    0.00 | 0.2842 |     - |     - |   1,797 B |
|    CreateSHA1Hash |  After |         hunter2 |   534.769 ns |  7.9382 ns |  7.4254 ns |  0.33 |    0.01 | 0.0677 |     - |     - |     433 B |