### PR TITLE
Add Microsoft.NET.Test.Sdk To Test Project

### DIFF
--- a/Functions.Tests/Functions.Tests.csproj
+++ b/Functions.Tests/Functions.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This allows other test runners (Rider) to find
and execute tests in the test project.