### PR TITLE
Use latest Azure Storage libraries

### DIFF
--- a/Functions/BlobStorage.cs
+++ b/Functions/BlobStorage.cs
@@ -1,10 +1,10 @@
 ﻿using System.Diagnostics;
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
 
 namespace Functions
 {
@@ -13,28 +13,23 @@ namespace Functions
     /// </summary>
     public class BlobStorage
     {
-        private readonly CloudBlobContainer _container;
-        private readonly ILogger _log;
+        private readonly ILogger<BlobStorage> _log;
+        private readonly BlobContainerClient _blobContainerClient;
 
         /// <summary>
         /// Create a new Blob storage access instance
         /// </summary>
         /// <param name="configuration">Configuration instance</param>
-        /// <param name="log">Logger instance to emit diagnostic information to</param>
-        public BlobStorage(IConfiguration configuration, ILogger<BlobStorage> log)
+        /// <param name="log">Logger instance to emit diagnostic information</param>
+        /// <param name="blobServiceClient">Client instance for accessing blob storage</param>
+        public BlobStorage(IConfiguration configuration, ILogger<BlobStorage> log, BlobServiceClient blobServiceClient)
         {
             _log = log;
-            ServicePointManager.UseNagleAlgorithm = false;
-            ServicePointManager.Expect100Continue = false;
-            ServicePointManager.DefaultConnectionLimit = 100;
 
-            var storageConnectionString = configuration["PwnedPasswordsConnectionString"];
             var containerName = configuration["BlobContainerName"];
 
-            var storageAccount = CloudStorageAccount.Parse(storageConnectionString);
-            var blobClient = storageAccount.CreateCloudBlobClient();
             _log.LogInformation("Querying container: {ContainerName}", containerName);
-            _container = blobClient.GetContainerReference(containerName);
+            _blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
         }
 
         /// <summary>
@@ -45,19 +40,19 @@ namespace Functions
         public async Task<BlobStorageEntry?> GetByHashesByPrefix(string hashPrefix)
         {
             var fileName = $"{hashPrefix}.txt";
-            var blockBlob = _container.GetBlockBlobReference(fileName);
+            var blobClient = _blobContainerClient.GetBlobBaseClient(fileName);
 
             try
             {
                 var sw = new Stopwatch();
                 sw.Start();
-                var blobStream = await blockBlob.OpenReadAsync();
+                var response = await blobClient.DownloadStreamingAsync();
                 sw.Stop();
                 _log.LogInformation("Blob Storage stream queried in {ElapsedMilliseconds}ms", sw.ElapsedMilliseconds.ToString("n0"));
 
-                return new BlobStorageEntry(blobStream, blockBlob.Properties.LastModified);
+                return new BlobStorageEntry(response.Value.Content, response.Value.Details.LastModified);
             }
-            catch (StorageException ex) when (ex.RequestInformation?.HttpStatusCode == 404)
+            catch (RequestFailedException ex) when (ex.Status == 404)
             {
                 _log.LogWarning("Blob Storage couldn't find file \"{FileName}\"", fileName);
             }

--- a/Functions/Functions.csproj
+++ b/Functions/Functions.csproj
@@ -5,11 +5,12 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.9.0-beta.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Functions/Functions.csproj
+++ b/Functions/Functions.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.9.0-beta.4" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.9.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.2.0" />

--- a/Functions/Program.cs
+++ b/Functions/Program.cs
@@ -19,11 +19,7 @@ namespace Functions
                 {
                     var storageConnectionString = context.Configuration["PwnedPasswordsConnectionString"];
 
-                    services.AddAzureClients(
-                        azure =>
-                        {
-                            azure.AddBlobServiceClient(storageConnectionString);
-                        });
+                    services.AddAzureClients(azure => azure.AddBlobServiceClient(storageConnectionString));
 
                     services.AddSingleton<BlobStorage>();
                 })


### PR DESCRIPTION
The function app references the deprecated [WindowsAzure.Storage](https://www.nuget.org/packages/WindowsAzure.Storage/) NuGet package for accessing the Blobs. Although there is a newer version of the library [Microsoft.Azure.Storage.Blob](https://www.nuget.org/packages/Microsoft.Azure.Storage.Blob/) which provides API parity, it's advice to move to [Azure.Storage.Blobs](https://www.nuget.org/packages/Azure.Storage.Blobs).

As noted in https://github.com/Azure/azure-storage-net/issues/732#issuecomment-745749919 `CloudBlobContainer` is not thread safe, while the new client is.

This change also has a perf benefit. While testing on the local box with storage emulator, i experienced reduced end to end response times:
NuGet | Average | Min | Max | Std. Dev.
-- | -- | -- | -- | --
WindowsAzure.Storage | 110 | 97 | 174 | 14.19
Azure.Storage.Blobs | 53 | 44 | 98 | 8.34

It must be noted that this references a beta package, where the `DownloadStreamingAsync` is implemented. I didn't manage to find a suitable alternative, which would not make 2 round trips to the storage for accessing the properties.








