### PR TITLE
dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Australia/Brisbane"


### PR DESCRIPTION
Enables dependabot to keep the dependencies up-to-date.

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically