### PR TITLE
Miscellaneous code cleanups

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,93 +1,26 @@
-# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
-###############################
-# Core EditorConfig Options   #
-###############################
-# All files
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
 [*]
-indent_style = space
-# Code files
-[*.{cs,csx,vb,vbx}]
-indent_size = 4
 insert_final_newline = true
-charset = utf-8-bom
-###############################
-# .NET Coding Conventions     #
-###############################
-[*.{cs,vb}]
-# Organize usings
-dotnet_sort_system_directives_first = true
-# this. preferences
-dotnet_style_qualification_for_field = false:silent
-dotnet_style_qualification_for_property = false:silent
-dotnet_style_qualification_for_method = false:silent
-dotnet_style_qualification_for_event = false:silent
-# Language keywords vs BCL types preferences
-dotnet_style_predefined_type_for_locals_parameters_members = true:silent
-dotnet_style_predefined_type_for_member_access = true:silent
-# Parentheses preferences
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
-# Modifier preferences
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
-dotnet_style_readonly_field = true:suggestion
-# Expression-level preferences
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:silent
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_style_prefer_conditional_expression_over_return = true:silent
-###############################
-# Naming Conventions          #
-###############################
-# Style Definitions
-dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
-# Use PascalCase for constant fields  
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds            = field
-dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
-dotnet_naming_symbols.constant_fields.required_modifiers          = const
-###############################
-# C# Coding Conventions       #
-###############################
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[project.json]
+indent_size = 2
+
+# Generated code
+[*{_AssemblyInfo.cs,.notsupported.cs}]
+generated_code = true
+
+# C# files
 [*.cs]
-# var preferences
-csharp_style_var_for_built_in_types = true:silent
-csharp_style_var_when_type_is_apparent = true:silent
-csharp_style_var_elsewhere = true:silent
-# Expression-bodied members
-csharp_style_expression_bodied_methods = false:silent
-csharp_style_expression_bodied_constructors = false:silent
-csharp_style_expression_bodied_operators = false:silent
-csharp_style_expression_bodied_properties = true:silent
-csharp_style_expression_bodied_indexers = true:silent
-csharp_style_expression_bodied_accessors = true:silent
-# Pattern matching preferences
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-# Null-checking preferences
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
-# Modifier preferences
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
-# Expression-level preferences
-csharp_prefer_braces = true:silent
-csharp_style_deconstructed_variable_declaration = true:suggestion
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_style_pattern_local_over_anonymous_function = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-###############################
-# C# Formatting Rules         #
-###############################
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
@@ -96,28 +29,173 @@ csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
+
 # Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
 csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
 csharp_indent_switch_labels = true
-csharp_indent_labels = flush_left
+csharp_indent_labels = one_less_than_current
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Types: use keywords instead of BCL types, and permit var only when the type is clear
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+# Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:silent
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Code quality
+dotnet_style_readonly_field = true:suggestion
+dotnet_code_quality_unused_parameters = non_public:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:silent
+csharp_style_expression_bodied_constructors = true:silent
+csharp_style_expression_bodied_operators = true:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = true:silent
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
 # Space preferences
 csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
 csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
 csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
 csharp_space_between_method_declaration_parameter_list_parentheses = false
 csharp_space_between_parentheses = false
-csharp_space_before_colon_in_inheritance_clause = true
-csharp_space_after_colon_in_inheritance_clause = true
-csharp_space_around_binary_operators = before_and_after
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
-csharp_space_between_method_call_name_and_opening_parenthesis = false
-csharp_space_between_method_call_empty_parameter_list_parentheses = false
-# Wrapping preferences
-csharp_preserve_single_line_statements = true
-csharp_preserve_single_line_blocks = true
-###############################
-# VB Coding Conventions       #
-###############################
-[*.vb]
-# Modifier preferences
-visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion
+csharp_space_between_square_brackets = false
+
+# Analyzers
+dotnet_code_quality.CA1052.api_surface = private, internal
+dotnet_code_quality.CA1802.api_surface = private, internal
+dotnet_code_quality.CA1822.api_surface = private, internal
+dotnet_code_quality.CA2208.api_surface = public
+
+# License header
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
+
+# C++ Files
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+[*.{csproj,vbproj,proj,nativeproj,locproj}]
+charset = utf-8
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# YAML config files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd,bat}]
+end_of_line = crlf

--- a/Functions.Tests/Helpers/TestFunctionContext.cs
+++ b/Functions.Tests/Helpers/TestFunctionContext.cs
@@ -1,16 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+
 using Microsoft.Azure.Functions.Worker;
+
+using Moq;
 
 namespace Functions.Tests
 {
     // Copied from: https://github.com/Azure/azure-functions-dotnet-worker/blob/main/test/DotNetWorkerTests/TestFunctionContext.cs
-    internal class TestFunctionContext : FunctionContext, IDisposable
+    internal class TestFunctionContext : FunctionContext
     {
         private readonly FunctionInvocation _invocation;
 
-        public TestFunctionContext()
-            : this(new TestFunctionDefinition(), new TestFunctionInvocation())
+        public TestFunctionContext() : this(new TestFunctionDefinition(), new TestFunctionInvocation())
         {
         }
 
@@ -18,19 +20,16 @@ namespace Functions.Tests
         {
             FunctionDefinition = functionDefinition;
             _invocation = invocation;
-
             BindingContext = new TestBindingContext(this);
         }
 
-        public bool IsDisposed { get; private set; }
-
-        public override IServiceProvider InstanceServices { get; set; }
+        public override IServiceProvider InstanceServices { get; set; } = Mock.Of<IServiceProvider>();
 
         public override FunctionDefinition FunctionDefinition { get; }
 
-        public override IDictionary<object, object> Items { get; set; }
+        public override IDictionary<object, object> Items { get; set; } = new Dictionary<object, object>();
 
-        public override IInvocationFeatures Features { get; }
+        public override IInvocationFeatures Features { get; } = Mock.Of<IInvocationFeatures>();
 
         public override string InvocationId => _invocation.Id;
 
@@ -39,22 +38,14 @@ namespace Functions.Tests
         public override TraceContext TraceContext => _invocation.TraceContext;
 
         public override BindingContext BindingContext { get; }
-
-        public void Dispose()
-        {
-            IsDisposed = true;
-        }
     }
 
     internal class TestBindingContext : BindingContext
     {
-        private readonly FunctionContext _functionContext;
-
         public TestBindingContext(FunctionContext functionContext)
         {
-            _functionContext = functionContext ?? throw new ArgumentNullException(nameof(functionContext));
         }
 
-        public override IReadOnlyDictionary<string, object?> BindingData => null;
+        public override IReadOnlyDictionary<string, object?> BindingData => new Dictionary<string, object?>();
     }
 }

--- a/Functions.Tests/Helpers/TestFunctionDefinition.cs
+++ b/Functions.Tests/Helpers/TestFunctionDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+
 using Microsoft.Azure.Functions.Worker;
 
 namespace Functions.Tests
@@ -13,21 +14,25 @@ namespace Functions.Tests
         public static readonly string DefaultId = "TestId";
         public static readonly string DefaultName = "TestName";
 
-        private static readonly Dictionary<string, object> _properties = new()
+        private static readonly Dictionary<string, object> s_properties = new()
         {
             { "TestPropertyKey", "TestPropertyValue" }
         };
 
-        public TestFunctionDefinition(string functionId = null, IDictionary<string, BindingMetadata> inputBindings = null, IDictionary<string, BindingMetadata> outputBindings = null, IEnumerable<FunctionParameter> parameters = null)
+        public TestFunctionDefinition()
         {
-            if (functionId is not null)
-            {
-                Id = functionId;
-            }
+            Id = "";
+            Parameters = ImmutableArray<FunctionParameter>.Empty;
+            InputBindings = ImmutableDictionary<string, BindingMetadata>.Empty;
+            OutputBindings = ImmutableDictionary<string, BindingMetadata>.Empty;
+        }
 
-            Parameters = parameters == null ? ImmutableArray<FunctionParameter>.Empty : parameters.ToImmutableArray();
-            InputBindings = inputBindings == null ? ImmutableDictionary<string, BindingMetadata>.Empty : inputBindings.ToImmutableDictionary();
-            OutputBindings = outputBindings == null ? ImmutableDictionary<string, BindingMetadata>.Empty : outputBindings.ToImmutableDictionary();
+        public TestFunctionDefinition(IDictionary<string, BindingMetadata> inputBindings, IDictionary<string, BindingMetadata> outputBindings, IEnumerable<FunctionParameter> parameters)
+        {
+            Id = "";
+            Parameters = parameters.ToImmutableArray();
+            InputBindings = inputBindings.ToImmutableDictionary();
+            OutputBindings = outputBindings.ToImmutableDictionary();
         }
 
         public override ImmutableArray<FunctionParameter> Parameters { get; }
@@ -72,7 +77,7 @@ namespace Functions.Tests
 
             for (int i = 0; i < paramTypes.Length; i++)
             {
-                parameters.Add(new FunctionParameter($"Parameter{i}", paramTypes[i], _properties.ToImmutableDictionary()));
+                parameters.Add(new FunctionParameter($"Parameter{i}", paramTypes[i], s_properties.ToImmutableDictionary()));
             }
 
             return new TestFunctionDefinition(inputBindings: inputs, outputBindings: outputs, parameters: parameters);

--- a/Functions.Tests/Helpers/TestFunctionInvocation.cs
+++ b/Functions.Tests/Helpers/TestFunctionInvocation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using Microsoft.Azure.Functions.Worker;
 
 namespace Functions.Tests
@@ -6,23 +7,12 @@ namespace Functions.Tests
     // Copied from: https://github.com/Azure/azure-functions-dotnet-worker/blob/main/test/DotNetWorkerTests/TestFunctionInvocation.cs
     public class TestFunctionInvocation : FunctionInvocation
     {
-        public TestFunctionInvocation(string id = null, string functionId = null)
+        public TestFunctionInvocation()
         {
-            if (id is not null)
-            {
-                Id = id;
-            }
-
-            if (functionId is not null)
-            {
-                FunctionId = functionId;
-            }
         }
 
         public override string Id { get; } = Guid.NewGuid().ToString();
-
         public override string FunctionId { get; } = Guid.NewGuid().ToString();
-
         public override TraceContext TraceContext { get; } = new TestTraceContext(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
     }
 
@@ -35,7 +25,6 @@ namespace Functions.Tests
         }
 
         public override string TraceParent { get; }
-
         public override string TraceState { get; }
     }
 }

--- a/Functions.Tests/Helpers/TestHttpRequestData.cs
+++ b/Functions.Tests/Helpers/TestHttpRequestData.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Claims;
+
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 
@@ -9,37 +10,22 @@ namespace Functions.Tests
 {
     public class TestHttpRequestData : HttpRequestData
     {
-        public TestHttpRequestData(FunctionContext functionContext, Stream body = null, string method = "GET", string url = null)
-            : base(functionContext)
+        public TestHttpRequestData(FunctionContext functionContext) : base(functionContext)
         {
-            Body = body ?? new MemoryStream();
+            Body = new MemoryStream();
             Headers = new HttpHeadersCollection();
             Cookies = new List<IHttpCookie>();
-            Url = new Uri(url ?? "https://localhost");
+            Url = new Uri("https://localhost");
             Identities = new List<ClaimsIdentity>();
-            Method = method;
+            Method = "GET";
         }
 
         public override Stream Body { get; }
-
         public override HttpHeadersCollection Headers { get; }
-
         public override IReadOnlyCollection<IHttpCookie> Cookies { get; }
-
         public override Uri Url { get; }
-
         public override IEnumerable<ClaimsIdentity> Identities { get; }
-
         public override string Method { get; }
-
-        public override HttpResponseData CreateResponse()
-        {
-            var response = new TestHttpResponseData(this.FunctionContext);
-
-            response.Body = new MemoryStream();
-            response.Headers = new HttpHeadersCollection();
-
-            return response;
-        }
+        public override HttpResponseData CreateResponse() => new TestHttpResponseData(FunctionContext) { Body = new MemoryStream(), Headers = new HttpHeadersCollection() };
     }
 }

--- a/Functions.Tests/Helpers/TestHttpResponseData.cs
+++ b/Functions.Tests/Helpers/TestHttpResponseData.cs
@@ -1,26 +1,27 @@
 ﻿using System.IO;
 using System.Net;
+
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+
+using Moq;
 
 namespace Functions.Tests
 {
     public class TestHttpResponseData : HttpResponseData
     {
-        public TestHttpResponseData(FunctionContext functionContext, HttpStatusCode status)
-            : this(functionContext)
+        public TestHttpResponseData(FunctionContext functionContext, HttpStatusCode status) : this(functionContext)
         {
             StatusCode = status;
         }
 
         public TestHttpResponseData(FunctionContext functionContext) : base(functionContext)
         {
-
         }
 
         public override HttpStatusCode StatusCode { get; set; }
-        public override HttpHeadersCollection Headers { get; set; }
-        public override Stream Body { get; set; }
-        public override HttpCookies Cookies { get; }
+        public override HttpHeadersCollection Headers { get; set; } = new HttpHeadersCollection();
+        public override Stream Body { get; set; } = Stream.Null;
+        public override HttpCookies Cookies { get; } = Mock.Of<HttpCookies>();
     }
 }

--- a/Functions.Tests/RangeTests.cs
+++ b/Functions.Tests/RangeTests.cs
@@ -2,33 +2,49 @@
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
+
 using FluentAssertions;
+
+using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+
 using Moq;
+
 using Xunit;
 
 namespace Functions.Tests
 {
     public class RangeTests
     {
+        private static readonly ILogger<Range> s_nullLogger = NullLoggerFactory.Instance.CreateLogger<Range>();
+
         [Fact]
         public async Task Returns_ok_given_valid_hashprefix()
         {
-            var validHashPrefix = "ABCDE";
-            var lastModified = "Fri, 01 Jan 2021 00:00:00 GMT";
+            string validHashPrefix = "ABCDE";
             var request = new TestHttpRequestData(new TestFunctionContext());
-            var dummyLogger = NullLoggerFactory.Instance.CreateLogger<Range>();
-            var returnHashFile = new BlobStorageEntry(Stream.Null, DateTimeOffset.Parse(lastModified));
-
+            var returnHashFile = new BlobStorageEntry(Stream.Null, DateTimeOffset.UtcNow);
             var mockStorage = new Mock<IStorageService>();
             mockStorage.Setup(s => s.GetHashesByPrefix(validHashPrefix)).ReturnsAsync(returnHashFile);
 
-            var function = new Range(mockStorage.Object, dummyLogger);
-
-            var actualResponse = await function.RunAsync(request, validHashPrefix);
+            var function = new Range(mockStorage.Object, s_nullLogger);
+            HttpResponseData actualResponse = await function.RunAsync(request, validHashPrefix);
 
             actualResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task Returns_notfound_if_hashprefix_doesnt_exist()
+        {
+            var request = new TestHttpRequestData(new TestFunctionContext());
+            var mockStorage = new Mock<IStorageService>();
+            mockStorage.Setup(s => s.GetHashesByPrefix(It.IsAny<string>())).ReturnsAsync(default(BlobStorageEntry));
+
+            var function = new Range(mockStorage.Object, s_nullLogger);
+            HttpResponseData actualResponse = await function.RunAsync(request, "ABCDE");
+
+            actualResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
 
         [Theory]
@@ -40,11 +56,9 @@ namespace Functions.Tests
         {
             var request = new TestHttpRequestData(new TestFunctionContext());
             var mockStorage = new Mock<IStorageService>();
-            var dummyLogger = NullLoggerFactory.Instance.CreateLogger<Range>();
 
-            var function = new Range(mockStorage.Object, dummyLogger);
-
-            var actualResponse = await function.RunAsync(request, invalidHashPrefix);
+            var function = new Range(mockStorage.Object, s_nullLogger);
+            HttpResponseData actualResponse = await function.RunAsync(request, invalidHashPrefix);
 
             actualResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         }
@@ -52,16 +66,13 @@ namespace Functions.Tests
         [Fact]
         public async Task Returns_internal_server_error_when_something_goes_wrong()
         {
-            var validHashPrefix = "ABCDE";
+            string validHashPrefix = "ABCDE";
             var request = new TestHttpRequestData(new TestFunctionContext());
-            var dummyLogger = NullLoggerFactory.Instance.CreateLogger<Range>();
-
             var mockStorage = new Mock<IStorageService>();
             mockStorage.Setup(s => s.GetHashesByPrefix(It.IsAny<string>())).ThrowsAsync(new Exception());
 
-            var function = new Range(mockStorage.Object, dummyLogger);
-
-            var actualResponse = await function.RunAsync(request, validHashPrefix);
+            var function = new Range(mockStorage.Object, s_nullLogger);
+            HttpResponseData actualResponse = await function.RunAsync(request, validHashPrefix);
 
             actualResponse.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
         }

--- a/Functions/BlobStorage.cs
+++ b/Functions/BlobStorage.cs
@@ -1,8 +1,11 @@
 ﻿using System.Diagnostics;
 using System.Threading.Tasks;
+
 using Azure;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -26,7 +29,7 @@ namespace Functions
         {
             _log = log;
 
-            var containerName = configuration["BlobContainerName"];
+            string containerName = configuration["BlobContainerName"];
 
             _log.LogInformation("Querying container: {ContainerName}", containerName);
             _blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
@@ -39,15 +42,15 @@ namespace Functions
         /// <returns>Returns a <see cref="BlobStorageEntry"/> with a stream to access the k-anonymity SHA-1 file</returns>
         public async Task<BlobStorageEntry?> GetHashesByPrefix(string hashPrefix)
         {
-            var fileName = $"{hashPrefix}.txt";
-            var blobClient = _blobContainerClient.GetBlobBaseClient(fileName);
+            string fileName = $"{hashPrefix}.txt";
+            BlobBaseClient blobClient = _blobContainerClient.GetBlobBaseClient(fileName);
 
             try
             {
                 var sw = Stopwatch.StartNew();
 
                 sw.Start();
-                var response = await blobClient.DownloadStreamingAsync();
+                Response<BlobDownloadStreamingResult>? response = await blobClient.DownloadStreamingAsync();
                 sw.Stop();
 
                 _log.LogInformation("Hash file downloaded in {ElapsedMilliseconds}ms", sw.ElapsedMilliseconds.ToString("n0"));

--- a/Functions/Hash.cs
+++ b/Functions/Hash.cs
@@ -18,7 +18,7 @@ namespace Functions
         /// <returns>The input string as a SHA-1 hash</returns>
         public static string CreateSHA1Hash(this string input, string source = "UTF8")
         {
-            var encoding = source == "UTF8" ? Encoding.UTF8 : Encoding.Unicode;
+            Encoding encoding = source == "UTF8" ? Encoding.UTF8 : Encoding.Unicode;
             Span<byte> hash = stackalloc byte[20];
             _ = SHA1.HashData(encoding.GetBytes(input), hash);
             return Convert.ToHexString(hash);

--- a/Functions/Program.cs
+++ b/Functions/Program.cs
@@ -1,5 +1,4 @@
-﻿using System.Net;
-using Microsoft.Extensions.Azure;
+﻿using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -9,11 +8,11 @@ namespace Functions
     {
         public static void Main()
         {
-            var host = new HostBuilder()
+            IHost host = new HostBuilder()
                 .ConfigureFunctionsWorkerDefaults()
                 .ConfigureServices((context, services) =>
                 {
-                    var storageConnectionString = context.Configuration["PwnedPasswordsConnectionString"];
+                    string storageConnectionString = context.Configuration["PwnedPasswordsConnectionString"];
 
                     services
                     .AddSingleton<BlobStorage>()

--- a/Functions/Range.cs
+++ b/Functions/Range.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
@@ -43,7 +44,7 @@ namespace Functions
 
             try
             {
-                var entry = await _blobStorage.GetHashesByPrefix(hashPrefix.ToUpper());
+                BlobStorageEntry? entry = await _blobStorage.GetHashesByPrefix(hashPrefix.ToUpper());
                 return entry == null ? NotFound(req) : File(req, entry);
             }
             catch (Exception ex)
@@ -55,21 +56,21 @@ namespace Functions
 
         private static HttpResponseData BadRequest(HttpRequestData req)
         {
-            var response = req.CreateResponse(HttpStatusCode.BadRequest);
+            HttpResponseData response = req.CreateResponse(HttpStatusCode.BadRequest);
             response.WriteString("The hash prefix was not in a valid format");
             return response;
         }
 
         private static HttpResponseData NotFound(HttpRequestData req)
         {
-            var response = req.CreateResponse(HttpStatusCode.NotFound);
+            HttpResponseData response = req.CreateResponse(HttpStatusCode.NotFound);
             response.WriteString("The hash prefix was not found");
             return response;
         }
 
         private static HttpResponseData File(HttpRequestData req, BlobStorageEntry entry)
         {
-            var response = req.CreateResponse(HttpStatusCode.OK);
+            HttpResponseData response = req.CreateResponse(HttpStatusCode.OK);
             response.Headers.Add(HeaderNames.LastModified, entry.LastModified.ToString("R"));
             response.Body = entry.Stream;
             return response;
@@ -77,7 +78,7 @@ namespace Functions
 
         private static HttpResponseData InternalServerError(HttpRequestData req)
         {
-            var response = req.CreateResponse(HttpStatusCode.InternalServerError);
+            HttpResponseData response = req.CreateResponse(HttpStatusCode.InternalServerError);
             response.WriteString("Something went wrong.");
             return response;
         }


### PR DESCRIPTION
* Changing .editorconfig to match [dotnet/runtime](https://github.com/dotnet/runtime/blob/main/.editorconfig) defaults.
* Fixing `nullable` warnings.