### PR TITLE
More granular review requesting for CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,24 @@
-*       @troyhunt
+# This is the CODEOWNERS file for Pwned Passwords Azure Functions
+
+# These people are the default owners for anything in the repo.
+# Unless a later match takes precedence, these people will be
+# requested to review PRs
+*                    @troyhunt
+
+# Any C# source files
+*.cs                 @stebet
+
+# Any C# project files
+*.csproj	         @stebet
+
+# Any Solution files
+*sln	             @stebet
+
+# Any markdown files
+*.md                 @stebet
+
+# Any .yml configuration files
+*.yml                @stebet
+
+# Repo Security policy
+/.github/SECURITY.md @troyhunt


### PR DESCRIPTION
This should be more granular for code reviews

## Description

<!--
Please include a summary of the change(s) and/or  which issue(s) are fixed. 
This includes of any changes to current behaviour, new services required, and any breaking changes
If this closes an issue, please include "closes #XXXX" in your comment to auto-close the issue
-->

To reduce lots of assignments to different people, a more granular approach has been taken with CODEOWNERS to reduce unnecessary review assignments.

## Checklist:
<!-- Please replace every instance of `[ ]` with `[X]` to indicate you have completed the criteria -->

- [x] I confirm that my submission adheres to the [Code of Conduct](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/CODE_OF_CONDUCT.md).
- [x] I have tested that the code works with sample data and verified all tests are passing
- [x] I have verified that any tests that I have supplied with this Pull Request work and I have fixed any code which caused pre-existing tests to fail.
- [x] I have updated the [README](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/README.md) with any changes in dependencies/configuration values.
- [x] I have linted my code to ensure that it is formatted correctly.

<!-- Thank you for your submission and for contributing to Have I Been Pwned's Pwned Passwords! -->
