### PR TITLE
Reverting back to .NET Core 3.1

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,6 +18,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
+        include-prerelease: true
 
     - name: Setup .NET 3.1 SDK
       uses: actions/setup-dotnet@v1

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,12 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     
-    - name: Setup .NET 6.0 SDK
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-        include-prerelease: true
-
     - name: Setup .NET 3.1 SDK
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/deploy-function.yml
+++ b/.github/workflows/deploy-function.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
+        include-prerelease: true
     
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1

--- a/.github/workflows/deploy-function.yml
+++ b/.github/workflows/deploy-function.yml
@@ -21,13 +21,7 @@ jobs:
     environment: dev
     steps:
     - uses: actions/checkout@v2
-    
-    - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-        include-prerelease: true
-    
+        
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:

--- a/Functions.Tests/HaveIBeenPwned.PwnedPasswords.Tests.csproj
+++ b/Functions.Tests/HaveIBeenPwned.PwnedPasswords.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>HaveIBeenPwned.PwnedPasswords.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/Functions.Tests/PwnedPasswordAppendTests.cs
+++ b/Functions.Tests/PwnedPasswordAppendTests.cs
@@ -12,7 +12,7 @@ namespace HaveIBeenPwned.PwnedPasswords.Tests
         [InlineData("c5c375930174561a95fca5388b45abad802a19cd", "C5C375930174561A95FCA5388B45ABAD802A19CD")]
         public void UppercaseSHA1Hash(string hash, string upperHash)
         {
-            PwnedPasswordAppend append = new() { SHA1Hash = hash };
+            PwnedPasswordAppend append = new PwnedPasswordAppend() { SHA1Hash = hash };
             Assert.Equal(upperHash, append.SHA1Hash);
         }
 
@@ -21,7 +21,7 @@ namespace HaveIBeenPwned.PwnedPasswords.Tests
         [InlineData("b4b9b02e6f09a9bd760f388b67351e2b", "B4B9B02E6F09A9BD760F388B67351E2B")]
         public void UppercaseNTLMHash(string hash, string upperHash)
         {
-            PwnedPasswordAppend append = new() { NTLMHash = hash };
+            PwnedPasswordAppend append = new PwnedPasswordAppend() { NTLMHash = hash };
             Assert.Equal(upperHash, append.NTLMHash);
         }
 
@@ -30,7 +30,7 @@ namespace HaveIBeenPwned.PwnedPasswords.Tests
         [InlineData("c5c375930174561a95fca5388b45abad802a19cd", "C5C37")]
         public void PartitionKey(string hash, string partitionKey)
         {
-            PwnedPasswordAppend append = new() { SHA1Hash = hash };
+            PwnedPasswordAppend append = new PwnedPasswordAppend() { SHA1Hash = hash };
             Assert.Equal(partitionKey, append.PartitionKey);
         }
 
@@ -39,7 +39,7 @@ namespace HaveIBeenPwned.PwnedPasswords.Tests
         [InlineData("c5c375930174561a95fca5388b45abad802a19cd", "5930174561A95FCA5388B45ABAD802A19CD")]
         public void RowKey(string hash, string rowKey)
         {
-            PwnedPasswordAppend append = new() { SHA1Hash = hash };
+            PwnedPasswordAppend append = new PwnedPasswordAppend() { SHA1Hash = hash };
             Assert.Equal(rowKey, append.RowKey);
         }
     }

--- a/Functions/ApplicationInsights.config
+++ b/Functions/ApplicationInsights.config
@@ -1,2 +1,0 @@
-﻿<ApplicationInsights>
-</ApplicationInsights>

--- a/Functions/BlobStorage.cs
+++ b/Functions/BlobStorage.cs
@@ -79,9 +79,9 @@ namespace HaveIBeenPwned.PwnedPasswords
 
             BlobClient? blobClient = _blobContainerClient.GetBlobClient(fileName);
 
-            using (MemoryStream memStream = new())
+            using (var memStream = new MemoryStream())
             {
-                using (StreamWriter writer = new(memStream))
+                using (var writer = new StreamWriter(memStream))
                 {
                     await writer.WriteAsync(hashPrefixFileContents);
                     await writer.FlushAsync();
@@ -101,11 +101,11 @@ namespace HaveIBeenPwned.PwnedPasswords
             string? fileName = $"{hashPrefix}.txt";
             BlobClient? blobClient = _blobContainerClient.GetBlobClient(fileName);
 
-            using (MemoryStream memStream = new())
+            using (var memStream = new MemoryStream())
             {
-                using (StreamWriter writer = new(memStream))
+                using (var writer = new StreamWriter(memStream))
                 {
-                    foreach(var item in hashes)
+                    foreach (var item in hashes)
                     {
                         writer.WriteLine($"{item.Key}:{item.Value:n0}");
                     }

--- a/Functions/Cloudflare.cs
+++ b/Functions/Cloudflare.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Http;
-using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -16,7 +15,7 @@ namespace HaveIBeenPwned.PwnedPasswords
     /// </summary>
     public sealed class Cloudflare
     {
-        private static readonly HttpClient s_httpClient = new();
+        private static readonly HttpClient s_httpClient = new HttpClient();
         private readonly ILogger _log;
         private readonly string _pwnedPasswordsUrl;
 

--- a/Functions/HaveIBeenPwned.PwnedPasswords.csproj
+++ b/Functions/HaveIBeenPwned.PwnedPasswords.csproj
@@ -1,19 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <ApplicationInsightsResourceId>/subscriptions/62e2a1e5-4eda-4c1e-805e-44a6c8f8afbd/resourceGroups/PwnedPasswords/providers/microsoft.insights/components/PwnedPasswordsOSS</ApplicationInsightsResourceId>
     <RootNamespace>HaveIBeenPwned.PwnedPasswords</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.18.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.5" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
     <PackageReference Include="Azure.Data.Tables" Version="12.2.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Functions/Models/BlobStorageEntry.cs
+++ b/Functions/Models/BlobStorageEntry.cs
@@ -8,5 +8,17 @@ namespace HaveIBeenPwned.PwnedPasswords.Models
     /// <summary>
     /// Blob storage entry
     /// </summary>
-    public record BlobStorageEntry(Stream Stream, DateTimeOffset LastModified, ETag ETag);
+    public class BlobStorageEntry
+    {
+        public Stream Stream { get; }
+        public DateTimeOffset LastModified { get; }
+        public ETag ETag { get; }
+
+        public BlobStorageEntry(Stream stream, DateTimeOffset lastModified, ETag etag)
+        {
+            Stream = stream;
+            LastModified = lastModified;
+            ETag = etag;
+        }
+    }
 }

--- a/Functions/TableStorage.cs
+++ b/Functions/TableStorage.cs
@@ -27,7 +27,7 @@ namespace HaveIBeenPwned.PwnedPasswords
         private readonly ILogger _log;
         private bool _initialized = false;
 
-        private static readonly HashSet<string> _localCache = new();
+        private static readonly HashSet<string> _localCache = new HashSet<string>();
 
         public TableStorage(IConfiguration configuration, ILogger<TableStorage> log)
         {

--- a/Functions/host.json
+++ b/Functions/host.json
@@ -21,7 +21,6 @@
         }
     },
     "logging": {
-        "fileLoggingMode": "debugOnly",
         "logLevel": {
             "Host.Results": "Information",
             "Function": "Information",
@@ -29,17 +28,8 @@
             "default": "None"
         },
         "applicationInsights": {
-            "enableLiveMetrics": true,
-            "enableDependencyTracking": true,
-            "enablePerformanceCountersCollection": true,
-            "httpAutoCollectionOptions": {
-                "enableW3CDistributedTracing": true,
-                "enableHttpTriggerExtendedInfoCollection": true,
-                "enableResponseHeaderInjection": true
-            },
             "samplingSettings": {
-                "excludedTypes": "Request,Exception",
-                "isEnabled": true
+                "isEnabled": false
             }
         }
     }


### PR DESCRIPTION
Reverting back to .NET Core 3.1 since .NET 5.0 and 6.0 currently have issues with Application Insights.