### PR TITLE
Fixing cache purge since it needs to purge as prefixes instead of files.

### DIFF
--- a/Functions/Implementations/Cloudflare/CdnStorage.cs
+++ b/Functions/Implementations/Cloudflare/CdnStorage.cs
@@ -37,8 +37,8 @@ public sealed class CdnStorage : ICdnStorage
     {
         async Task SendPurgeCommand(List<string> urisToPurge, CancellationToken cancellationToken = default)
         {
-            _log.LogInformation("Purging the following URIs from Cloudflare Cache: {URIs}", string.Join(", ", urisToPurge));
-            using (HttpResponseMessage? response = await _httpClient.PostAsJsonAsync(string.Empty, new { files = urisToPurge }, cancellationToken))
+            _log.LogInformation("Purging the following prefixes from Cloudflare Cache: {URIs}", string.Join(", ", urisToPurge));
+            using (HttpResponseMessage? response = await _httpClient.PostAsJsonAsync(string.Empty, new { prefixes = urisToPurge }, cancellationToken))
             {
                 try
                 {
@@ -66,7 +66,7 @@ public sealed class CdnStorage : ICdnStorage
 
         for (int i = 0; i < hashPrefixes.Count; i++)
         {
-            filesToPurge.Add(new UriBuilder(_options.Value.PwnedPasswordsBaseUrl) { Path = $"range/{hashPrefixes[i]}" }.Uri.ToString());
+            filesToPurge.Add($"{_options.Value.PwnedPasswordsBaseUrl}range/{hashPrefixes[i]}");
             if (filesToPurge.Count == 30)
             {
                 await SendPurgeCommand(filesToPurge, cancellationToken);


### PR DESCRIPTION
## Description

Fixing cache purge since it needs to purge as prefixes instead of files.

## Checklist:
- [X] I confirm that my submission adheres to the [Code of Conduct](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/CODE_OF_CONDUCT.md).
- [X] I have tested that the code works with sample data and verified all tests are passing
- [X] I have verified that any tests that I have supplied with this Pull Request work and I have fixed any code which caused pre-existing tests to fail.
- [X] I have updated the [README](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/README.md) with any changes in dependencies/configuration values.
- [X] I have linted my code to ensure that it is formatted correctly.
