### PR TITLE
Fixing extra newlines at the ends of blobs.

### DIFF
--- a/Functions.Tests/BlobStorageTests.cs
+++ b/Functions.Tests/BlobStorageTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using HaveIBeenPwned.PwnedPasswords.Implementations.Azure;
+
+using Xunit;
+
+namespace HaveIBeenPwned.PwnedPasswords.Tests;
+
+public class BlobStorageTests
+{
+    [Fact]
+    public void RendersHashesWithoutEndingNewline()
+    {
+        SortedDictionary<string, int> fakeHahes = new SortedDictionary<string, int>();
+        fakeHahes.Add("ABCDEF", 0);
+        fakeHahes.Add("FEDCBA", 1);
+
+        StringWriter writer = new StringWriter();
+        BlobStorage.RenderHashes(fakeHahes, writer);
+        Assert.Equal($"ABCDEF:0{writer.NewLine}FEDCBA:1", writer.ToString());
+    }
+}

--- a/Functions/Implementations/Azure/BlobStorage.cs
+++ b/Functions/Implementations/Azure/BlobStorage.cs
@@ -75,11 +75,7 @@ public class BlobStorage : IFileStorage
         {
             using (var writer = new StreamWriter(memStream))
             {
-                foreach (KeyValuePair<string, int> item in hashes)
-                {
-                    writer.WriteLine($"{item.Key}:{item.Value:n0}");
-                }
-
+                RenderHashes(hashes, writer);
                 writer.Flush();
                 memStream.Seek(0, SeekOrigin.Begin);
                 try
@@ -93,6 +89,22 @@ public class BlobStorage : IFileStorage
                     _log.LogWarning(ex, $"Unable to update blob {fileName} since ETag does not match.");
                     return false;
                 }
+            }
+        }
+    }
+
+    public static void RenderHashes(SortedDictionary<string, int> hashes, TextWriter writer)
+    {
+        int i = 0;
+        foreach (KeyValuePair<string, int> item in hashes)
+        {
+            if (++i < hashes.Count)
+            {
+                writer.WriteLine($"{item.Key}:{item.Value:n0}");
+            }
+            else
+            {
+                writer.Write($"{item.Key}:{item.Value:n0}");
             }
         }
     }


### PR DESCRIPTION
## Description

Adding a test and fix for erroneous extra lineendings added when rewriting blobs.

## Checklist:
<!-- Please replace every instance of `[ ]` with `[X]` to indicate you have completed the criteria -->

- [X] I confirm that my submission adheres to the [Code of Conduct](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/CODE_OF_CONDUCT.md).
- [x] I have tested that the code works with sample data and verified all tests are passing
- [X] I have verified that any tests that I have supplied with this Pull Request work and I have fixed any code which caused pre-existing tests to fail.
- [ ] I have updated the [README](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/README.md) with any changes in dependencies/configuration values.
- [ ] I have linted my code to ensure that it is formatted correctly.