### PR TITLE
Adding parallelism to function processes to do things faster.

### DIFF
--- a/Functions/Abstractions/IQueueStorage.cs
+++ b/Functions/Abstractions/IQueueStorage.cs
@@ -6,5 +6,5 @@ namespace HaveIBeenPwned.PwnedPasswords.Abstractions;
 public interface IQueueStorage
 {
     Task PushTransactionAsync(QueueTransactionEntry entry, CancellationToken cancellationToken = default);
-    Task PushPasswordsAsync(List<QueuePasswordEntry> entry, CancellationToken cancellationToken = default);
+    Task PushPasswordsAsync(QueuePasswordEntry[] entry, CancellationToken cancellationToken = default);
 }

--- a/Functions/Functions/Ingestion/ProcessTransaction.cs
+++ b/Functions/Functions/Ingestion/ProcessTransaction.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.Threading.Channels;
+
 namespace HaveIBeenPwned.PwnedPasswords.Functions.Ingestion;
 
 public class ProcessTransaction
@@ -24,6 +26,13 @@ public class ProcessTransaction
     [FunctionName("ProcessTransactionQueueItem")]
     public async Task Run([QueueTrigger("%TableNamespace%-transaction", Connection = "PwnedPasswordsConnectionString")] byte[] queueItem, CancellationToken cancellationToken)
     {
+        Channel<QueuePasswordEntry[]> channel = Channel.CreateBounded<QueuePasswordEntry[]>(new BoundedChannelOptions(16) { FullMode = BoundedChannelFullMode.Wait, SingleReader = false, SingleWriter = true });
+        Task[] queueTasks = new Task[16];
+
+        for(int i = 0; i < queueTasks.Length; i++)
+        {
+            queueTasks[i] = ProcessQueueItem(channel, cancellationToken);
+        }
 
         QueueTransactionEntry? item = JsonSerializer.Deserialize<QueueTransactionEntry>(Encoding.UTF8.GetString(queueItem));
         if (item == null)
@@ -47,7 +56,12 @@ public class ProcessTransaction
                             entries.Add(new QueuePasswordEntry { SubscriptionId = item.SubscriptionId, TransactionId = item.TransactionId, SHA1Hash = entry.SHA1Hash.ToUpperInvariant(), NTLMHash = entry.NTLMHash.ToUpperInvariant(), Prevalence = entry.Prevalence });
                             if (entries.Count == 100)
                             {
-                                await _queueStorage.PushPasswordsAsync(entries, cancellationToken).ConfigureAwait(false);
+                                QueuePasswordEntry[] items = entries.ToArray();
+                                if (!channel.Writer.TryWrite(items))
+                                {
+                                    await channel.Writer.WriteAsync(items, cancellationToken);
+                                }
+
                                 entries.Clear();
                             }
                         }
@@ -55,14 +69,33 @@ public class ProcessTransaction
 
                     if (entries.Count > 0)
                     {
-                        await _queueStorage.PushPasswordsAsync(entries, cancellationToken).ConfigureAwait(false);
+                        QueuePasswordEntry[] items = entries.ToArray();
+                        if (!channel.Writer.TryWrite(items))
+                        {
+                            await channel.Writer.WriteAsync(items, cancellationToken);
+                        }
                     }
                 }
+
+                channel.Writer.TryComplete();
+                await Task.WhenAll(queueTasks);
             }
         }
         catch (Exception e)
         {
             _log.LogError(e, "Error processing transaction with id = {TransactionId} for subscription {SubscriptionId}.", item.TransactionId, item.SubscriptionId);
+            channel.Writer.TryComplete(e);
+        }
+    }
+
+    private async Task ProcessQueueItem(Channel<QueuePasswordEntry[]> channel, CancellationToken cancellationToken = default)
+    {
+        while(await channel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (channel.Reader.TryRead(out QueuePasswordEntry[]? item) && item != null)
+            {
+                await _queueStorage.PushPasswordsAsync(item, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/Functions/Implementations/Azure/QueueStorage.cs
+++ b/Functions/Implementations/Azure/QueueStorage.cs
@@ -25,7 +25,7 @@ public class QueueStorage : IQueueStorage
     /// Push a append job to the queue
     /// </summary>
     /// <param name="append">The append request to push to the queue</param>
-    public async Task PushPasswordsAsync(List<QueuePasswordEntry> entries, CancellationToken cancellationToken = default)
+    public async Task PushPasswordsAsync(QueuePasswordEntry[] entries, CancellationToken cancellationToken = default)
     {
         await _queueClient.SendMessageAsync(JsonSerializer.Serialize(entries), cancellationToken).ConfigureAwait(false);
         foreach (QueuePasswordEntry? entry in entries)


### PR DESCRIPTION
## Description

Processing functions now start 16 worker tasks each when working on data, to try to complete them within the 10 minute function time limits.

## Checklist:
<!-- Please replace every instance of `[ ]` with `[X]` to indicate you have completed the criteria -->

- [X] I confirm that my submission adheres to the [Code of Conduct](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/CODE_OF_CONDUCT.md).
- [X] I have tested that the code works with sample data and verified all tests are passing
- [X] I have verified that any tests that I have supplied with this Pull Request work and I have fixed any code which caused pre-existing tests to fail.
- [ ] I have updated the [README](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/README.md) with any changes in dependencies/configuration values.
- [ ] I have linted my code to ensure that it is formatted correctly.

<!-- Thank you for your submission and for contributing to Have I Been Pwned's Pwned Passwords! -->
