### PR TITLE
Fixing number formatting to remove separators

### DIFF
--- a/Functions.Tests/BlobStorageTests.cs
+++ b/Functions.Tests/BlobStorageTests.cs
@@ -21,10 +21,10 @@ public class BlobStorageTests
     {
         SortedDictionary<string, int> fakeHahes = new SortedDictionary<string, int>();
         fakeHahes.Add("ABCDEF", 0);
-        fakeHahes.Add("FEDCBA", 1);
+        fakeHahes.Add("FEDCBA", 1234);
 
         StringWriter writer = new StringWriter();
         BlobStorage.RenderHashes(fakeHahes, writer);
-        Assert.Equal($"ABCDEF:0{writer.NewLine}FEDCBA:1", writer.ToString());
+        Assert.Equal($"ABCDEF:0{writer.NewLine}FEDCBA:1234", writer.ToString());
     }
 }

--- a/Functions/Implementations/Azure/BlobStorage.cs
+++ b/Functions/Implementations/Azure/BlobStorage.cs
@@ -100,11 +100,11 @@ public class BlobStorage : IFileStorage
         {
             if (++i < hashes.Count)
             {
-                writer.WriteLine($"{item.Key}:{item.Value:n0}");
+                writer.WriteLine($"{item.Key}:{item.Value:D}");
             }
             else
             {
-                writer.Write($"{item.Key}:{item.Value:n0}");
+                writer.Write($"{item.Key}:{item.Value:D}");
             }
         }
     }


### PR DESCRIPTION
## Description

Fixing bug where prevalence numbers were formatted with separators.

## Checklist:
- [X] I confirm that my submission adheres to the [Code of Conduct](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/CODE_OF_CONDUCT.md).
- [X] I have tested that the code works with sample data and verified all tests are passing
- [X] I have verified that any tests that I have supplied with this Pull Request work and I have fixed any code which caused pre-existing tests to fail.
- [ ] I have updated the [README](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/README.md) with any changes in dependencies/configuration values.
- [X] I have linted my code to ensure that it is formatted correctly.
