### PR TITLE
Batch ingestion entries by prefix for processing

### DIFF
--- a/Functions.Tests/BlobStorageTests.cs
+++ b/Functions.Tests/BlobStorageTests.cs
@@ -1,12 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 using HaveIBeenPwned.PwnedPasswords.Implementations.Azure;
 

--- a/Functions/Abstractions/IQueueStorage.cs
+++ b/Functions/Abstractions/IQueueStorage.cs
@@ -6,5 +6,5 @@ namespace HaveIBeenPwned.PwnedPasswords.Abstractions;
 public interface IQueueStorage
 {
     Task PushTransactionAsync(QueueTransactionEntry entry, CancellationToken cancellationToken = default);
-    Task PushPasswordsAsync(QueuePasswordEntry[] entry, CancellationToken cancellationToken = default);
+    Task PushPasswordsAsync(PasswordEntryBatch entryBatch, CancellationToken cancellationToken = default);
 }

--- a/Functions/Abstractions/ITableStorage.cs
+++ b/Functions/Abstractions/ITableStorage.cs
@@ -9,7 +9,7 @@ public interface ITableStorage
     Task<bool> IsTransactionConfirmedAsync(string subscriptionId, string transactionId, CancellationToken cancellationToken = default);
     Task<List<PwnedPasswordsIngestionValue>> GetTransactionValuesAsync(string subscriptionId, string transactionId, CancellationToken cancellationToken = default);
     Task<bool> ConfirmAppendDataAsync(string subscriptionId, PwnedPasswordsTransaction transaction, CancellationToken cancellationToken = default);
-    Task<bool> AddOrIncrementHashEntry(string subscriptionId, string transactionId, PwnedPasswordsIngestionValue value, CancellationToken cancellationToken = default);
+    Task<bool> AddOrIncrementHashEntry(PasswordEntryBatch batch, PasswordEntryBatch.PasswordEntry value, CancellationToken cancellationToken = default);
     Task<List<string>> GetModifiedHashPrefixes(CancellationToken cancellationToken = default);
     Task MarkHashPrefixAsModified(string prefix, CancellationToken cancellationToken = default);
 }

--- a/Functions/Functions/Ingestion/ProcessPwnedPasswordEntry.cs
+++ b/Functions/Functions/Ingestion/ProcessPwnedPasswordEntry.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Threading.Channels;
 
 namespace HaveIBeenPwned.PwnedPasswords.Functions.Ingestion;
 

--- a/Functions/Functions/Ingestion/ProcessPwnedPasswordEntry.cs
+++ b/Functions/Functions/Ingestion/ProcessPwnedPasswordEntry.cs
@@ -4,115 +4,91 @@ using System.Threading.Channels;
 
 namespace HaveIBeenPwned.PwnedPasswords.Functions.Ingestion;
 
-public class ProcessPwnedPasswordEntry
+public class ProcessPwnedPasswordEntryBatch
 {
-    private readonly ILogger<ProcessPwnedPasswordEntry> _log;
+    private readonly ILogger<ProcessPwnedPasswordEntryBatch> _log;
     private readonly ITableStorage _tableStorage;
     private readonly IFileStorage _blobStorage;
-    private readonly IQueueStorage _queueStorage;
 
     /// <summary>
     /// Pwned Passwords - Append handler
     /// </summary>
     /// <param name="blobStorage">The Blob storage</param>
-    public ProcessPwnedPasswordEntry(ILogger<ProcessPwnedPasswordEntry> log, ITableStorage tableStorage, IFileStorage blobStorage, IQueueStorage queueStorage)
+    public ProcessPwnedPasswordEntryBatch(ILogger<ProcessPwnedPasswordEntryBatch> log, ITableStorage tableStorage, IFileStorage blobStorage)
     {
         _log = log;
         _tableStorage = tableStorage;
         _blobStorage = blobStorage;
-        _queueStorage = queueStorage;
     }
 
     [FunctionName("ProcessAppendQueueItem")]
     public async Task Run([QueueTrigger("%TableNamespace%-ingestion", Connection = "PwnedPasswordsConnectionString")] byte[] queueItem, CancellationToken cancellationToken)
     {
-        var items = JsonSerializer.Deserialize<QueuePasswordEntry[]>(Encoding.UTF8.GetString(queueItem));
-        if (items != null)
+        var batch = JsonSerializer.Deserialize<PasswordEntryBatch>(Encoding.UTF8.GetString(queueItem));
+        if (batch != null)
         {
-            Channel<QueuePasswordEntry> channel = Channel.CreateBounded<QueuePasswordEntry>(new BoundedChannelOptions(Startup.Parallelism) { FullMode = BoundedChannelFullMode.Wait, SingleReader = false, SingleWriter = true });
-            Task[] queueTasks = new Task[Startup.Parallelism];
-            for (int i = 0; i < queueTasks.Length; i++)
+            // Let's set some activity tags and log scopes so we have event correlation in our logs!
+            Activity.Current?.AddTag("SubscriptionId", batch.SubscriptionId).AddTag("TransactionId", batch.TransactionId);
+            foreach (var item in batch.PasswordEntries)
             {
-                queueTasks[i] = ProcessQueueItem(channel);
-            }
-
-            foreach (QueuePasswordEntry item in items)
-            {
-                await channel.Writer.WriteAsync(item);
-            }
-
-            channel.Writer.TryComplete();
-            await Task.WhenAll(queueTasks);
-        }
-    }
-
-    private async Task ProcessQueueItem(Channel<QueuePasswordEntry> channel, CancellationToken cancellationToken = default)
-    {
-        while (await channel.Reader.WaitToReadAsync(cancellationToken))
-        {
-            if (channel.Reader.TryRead(out QueuePasswordEntry? item) && item != null)
-            {
-                await ProcessPasswordEntry(item, cancellationToken).ConfigureAwait(false);
-            }
-        }
-    }
-
-    private async Task ProcessPasswordEntry(QueuePasswordEntry item, CancellationToken cancellationToken)
-    {
-        // Let's set some activity tags and log scopes so we have event correlation in our logs!
-        Activity.Current?.AddTag("SubscriptionId", item.SubscriptionId).AddTag("TransactionId", item.TransactionId);
-        while (!await _tableStorage.AddOrIncrementHashEntry(item.SubscriptionId, item.TransactionId, new PwnedPasswordsIngestionValue { SHA1Hash = item.SHA1Hash, NTLMHash = item.NTLMHash, Prevalence = item.Prevalence }, cancellationToken).ConfigureAwait(false))
-        {
-        }
-
-        string prefix = item.SHA1Hash[..5];
-        string suffix = item.SHA1Hash[5..];
-
-        await _tableStorage.MarkHashPrefixAsModified(prefix, cancellationToken).ConfigureAwait(false);
-
-        bool blobUpdated = false;
-        while (!blobUpdated)
-        {
-            try
-            {
-                blobUpdated = await ParseAndUpdateHashFile(item, prefix, suffix, cancellationToken).ConfigureAwait(false);
-                if (!blobUpdated)
+                while (!await _tableStorage.AddOrIncrementHashEntry(batch, item, cancellationToken).ConfigureAwait(false))
                 {
-                    _log.LogWarning("Subscription {SubscriptionId} failed to updated blob {HashPrefix} as part of transaction {TransactionId}! Will retry!", item.SubscriptionId, prefix, item.TransactionId);
                 }
-            }
-            catch (FileNotFoundException)
-            {
-                _log.LogError("Subscription {SubscriptionId} is unable to find a hash file with prefix {prefix} as part of transaction {TransactionId}. Something is wrong as this shouldn't happen!", item.SubscriptionId, prefix, item.TransactionId);
-                return;
+
+                string prefix = batch.Prefix;
+                string suffix = item.SHA1Hash[5..];
+
+                await _tableStorage.MarkHashPrefixAsModified(prefix, cancellationToken).ConfigureAwait(false);
+
+                bool blobUpdated = false;
+                while (!blobUpdated)
+                {
+                    try
+                    {
+                        blobUpdated = await ParseAndUpdateHashFile(batch, cancellationToken).ConfigureAwait(false);
+                        if (!blobUpdated)
+                        {
+                            _log.LogWarning("Subscription {SubscriptionId} failed to updated blob {HashPrefix} as part of transaction {TransactionId}! Will retry!", batch.SubscriptionId, prefix, batch.TransactionId);
+                        }
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        _log.LogError("Subscription {SubscriptionId} is unable to find a hash file with prefix {prefix} as part of transaction {TransactionId}. Something is wrong as this shouldn't happen!", batch.SubscriptionId, prefix, batch.TransactionId);
+                        return;
+                    }
+                }
+
+                _log.LogInformation("Subscription {SubscriptionId} successfully updated blob {HashPrefix} as part of transaction {TransactionId}!", batch.SubscriptionId, prefix, batch.TransactionId);
             }
         }
-
-        _log.LogInformation("Subscription {SubscriptionId} successfully updated blob {HashPrefix} as part of transaction {TransactionId}!", item.SubscriptionId, prefix, item.TransactionId);
     }
 
-    private async Task<bool> ParseAndUpdateHashFile(QueuePasswordEntry item, string prefix, string suffix, CancellationToken cancellationToken = default)
+    private async Task<bool> ParseAndUpdateHashFile(PasswordEntryBatch batch, CancellationToken cancellationToken = default)
     {
-        PwnedPasswordsFile blobFile = await _blobStorage.GetHashFileAsync(prefix, cancellationToken).ConfigureAwait(false);
+        PwnedPasswordsFile blobFile = await _blobStorage.GetHashFileAsync(batch.Prefix, cancellationToken).ConfigureAwait(false);
 
         // Let's read the existing blob into a sorted dictionary so we can write it back in order!
         SortedDictionary<string, int> hashes = ParseHashFile(blobFile);
 
         // We now have a sorted dictionary with the hashes for this prefix.
-        // Let's add or update the suffix with the prevalence count.
-        if (hashes.ContainsKey(suffix))
+        // Let's add or update the suffixes with the prevalence counts.
+        foreach (var item in batch.PasswordEntries)
         {
-            hashes[suffix] = hashes[suffix] + item.Prevalence;
-            _log.LogInformation("Subscription {SubscriptionId} updating suffix {HashSuffix} in blob {HashPrefix} from {PrevalenceBefore} to {PrevalenceAfter} as part of transaction {TransactionId}!", item.SubscriptionId, suffix, prefix, hashes[suffix] - item.Prevalence, hashes[suffix], item.TransactionId);
-        }
-        else
-        {
-            hashes.Add(suffix, item.Prevalence);
-            _log.LogInformation("Subscription {SubscriptionId} adding new suffix {HashSuffix} to blob {HashPrefix} with {Prevalence} as part of transaction {TransactionId}!", item.SubscriptionId, suffix, prefix, item.Prevalence, item.TransactionId);
+            string suffix = item.SHA1Hash[5..];
+            if (hashes.ContainsKey(suffix))
+            {
+                hashes[suffix] = hashes[suffix] + item.Prevalence;
+                _log.LogInformation("Subscription {SubscriptionId} updating suffix {HashSuffix} in blob {HashPrefix} from {PrevalenceBefore} to {PrevalenceAfter} as part of transaction {TransactionId}!", batch.SubscriptionId, suffix, batch.Prefix, hashes[suffix] - item.Prevalence, hashes[suffix], batch.TransactionId);
+            }
+            else
+            {
+                hashes.Add(suffix, item.Prevalence);
+                _log.LogInformation("Subscription {SubscriptionId} adding new suffix {HashSuffix} to blob {HashPrefix} with {Prevalence} as part of transaction {TransactionId}!", batch.SubscriptionId, suffix, batch.Prefix, item.Prevalence, batch.TransactionId);
+            }
         }
 
         // Now let's try to update the current blob with the new prevalence count!
-        return await _blobStorage.UpdateHashFileAsync(prefix, hashes, blobFile.ETag, cancellationToken).ConfigureAwait(false);
+        return await _blobStorage.UpdateHashFileAsync(batch.Prefix, hashes, blobFile.ETag, cancellationToken).ConfigureAwait(false);
     }
 
     private static SortedDictionary<string, int> ParseHashFile(PwnedPasswordsFile blobFile)

--- a/Functions/Implementations/Azure/QueueStorage.cs
+++ b/Functions/Implementations/Azure/QueueStorage.cs
@@ -25,12 +25,12 @@ public class QueueStorage : IQueueStorage
     /// Push a append job to the queue
     /// </summary>
     /// <param name="append">The append request to push to the queue</param>
-    public async Task PushPasswordsAsync(QueuePasswordEntry[] entries, CancellationToken cancellationToken = default)
+    public async Task PushPasswordsAsync(PasswordEntryBatch batch, CancellationToken cancellationToken = default)
     {
-        await _queueClient.SendMessageAsync(JsonSerializer.Serialize(entries), cancellationToken).ConfigureAwait(false);
-        foreach (QueuePasswordEntry? entry in entries)
+        await _queueClient.SendMessageAsync(JsonSerializer.Serialize(batch), cancellationToken).ConfigureAwait(false);
+        foreach (PasswordEntryBatch.PasswordEntry entry in batch.PasswordEntries)
         {
-            _log.LogInformation("Subscription {SubscriptionId} successfully queued SHA1 hash {SHA1} as part af transaction {TransactionId}", entry.SubscriptionId, entry.SHA1Hash, entry.TransactionId);
+            _log.LogInformation("Subscription {SubscriptionId} successfully queued SHA1 hash {SHA1} as part af transaction {TransactionId}", batch.SubscriptionId, entry.SHA1Hash, batch.TransactionId);
         }
     }
 }

--- a/Functions/Models/QueuePasswordEntry.cs
+++ b/Functions/Models/QueuePasswordEntry.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
 
 namespace HaveIBeenPwned.PwnedPasswords.Models;

--- a/Functions/Models/QueuePasswordEntry.cs
+++ b/Functions/Models/QueuePasswordEntry.cs
@@ -1,20 +1,29 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
 using System.Text.Json.Serialization;
 
 namespace HaveIBeenPwned.PwnedPasswords.Models;
 
-public class QueuePasswordEntry
+public class PasswordEntryBatch
 {
-    [JsonPropertyName("subscriptionId")]
+    [JsonPropertyName("subId")]
     public string SubscriptionId { get; set; } = "";
-    [JsonPropertyName("transactionId")]
+    [JsonPropertyName("trxId")]
     public string TransactionId { get; set; } = "";
-    [JsonPropertyName("sha1Hash")]
-    public string SHA1Hash { get; set; } = "";
-    [JsonPropertyName("ntlmHash")]
-    public string NTLMHash { get; set; } = "";
-    [JsonPropertyName("prevalence")]
-    public int Prevalence { get; set; }
+    [JsonPropertyName("prefix")]
+    public string Prefix { get; set; } = "";
+    [JsonPropertyName("items")]
+    public List<PasswordEntry> PasswordEntries { get; set; } = new List<PasswordEntry>();
+
+    public class PasswordEntry
+    {
+        [JsonPropertyName("sha1")]
+        public string SHA1Hash { get; set; } = "";
+        [JsonPropertyName("ntlm")]
+        public string NTLMHash { get; set; } = "";
+        [JsonPropertyName("num")]
+        public int Prevalence { get; set; }
+    }
 }


### PR DESCRIPTION
## Description

Now batching ingestion entries by prefix to reduce the risk of collisions while updating blobs.

## Checklist:
- [X] I confirm that my submission adheres to the [Code of Conduct](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/CODE_OF_CONDUCT.md).
- [X] I have tested that the code works with sample data and verified all tests are passing
- [X] I have verified that any tests that I have supplied with this Pull Request work and I have fixed any code which caused pre-existing tests to fail.
- [ ] I have updated the [README](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/README.md) with any changes in dependencies/configuration values.
- [X] I have linted my code to ensure that it is formatted correctly.
