### PR TITLE
Bug: Blob lines containing a decimal separator are omitted

### DIFF
--- a/Functions.Tests/BlobStorageTests.cs
+++ b/Functions.Tests/BlobStorageTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Policy;
 
 using HaveIBeenPwned.PwnedPasswords.Implementations.Azure;
 
@@ -22,5 +23,18 @@ public class BlobStorageTests
         StringWriter writer = new StringWriter();
         BlobStorage.RenderHashes(fakeHahes, writer);
         Assert.Equal($"ABCDEF:0{writer.NewLine}FEDCBA:1234", writer.ToString());
+    }
+
+    [Theory]
+    [InlineData("FDFD0D9BC12735B077ACF1FA63D6F42229D:1")]
+    [InlineData("FE5CCB19BA61C4C0873D391E987982FBBD3:86,453")]
+    public void ParsesCultureIntSuccessfully(string hashLine)
+    {
+        if (!string.IsNullOrEmpty(hashLine) && hashLine.Length >= 37 && hashLine[35] == ':' && int.TryParse(hashLine[36..].Replace(",", ""), out int currentPrevalence) && currentPrevalence > 0)
+        {
+            return;
+        }
+
+        Assert.True(false, $"Failed to parse {hashLine} successfully");
     }
 }

--- a/Functions/Functions/Ingestion/ProcessPwnedPasswordEntry.cs
+++ b/Functions/Functions/Ingestion/ProcessPwnedPasswordEntry.cs
@@ -110,7 +110,7 @@ public class ProcessPwnedPasswordEntryBatch
             while (hashLine != null)
             {
                 // Let's make sure we can parse this as a proper hash!
-                if (!string.IsNullOrEmpty(hashLine) && hashLine.Length >= 37 && hashLine[35] == ':' && int.TryParse(hashLine[36..], out int currentPrevalence))
+                if (!string.IsNullOrEmpty(hashLine) && hashLine.Length >= 37 && hashLine[35] == ':' && int.TryParse(hashLine[36..].Replace(",", ""), out int currentPrevalence) && currentPrevalence > 0)
                 {
                     hashes.Add(hashLine[..35], currentPrevalence);
                 }


### PR DESCRIPTION
## Description

Fixing a bug that cause lines containing a decimal separator to get omitted from updated blobs.

## Checklist:

- [X] I confirm that my submission adheres to the [Code of Conduct](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/CODE_OF_CONDUCT.md).
- [X] I have tested that the code works with sample data and verified all tests are passing
- [X] I have verified that any tests that I have supplied with this Pull Request work and I have fixed any code which caused pre-existing tests to fail.
- [ ] I have updated the [README](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/README.md) with any changes in dependencies/configuration values.
- [X] I have linted my code to ensure that it is formatted correctly.
