### PR TITLE
Adding ETag headers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <DebugType>embedded</DebugType>
+    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All"/>

--- a/Functions.Tests/HaveIBeenPwned.PwnedPasswords.Tests.csproj
+++ b/Functions.Tests/HaveIBeenPwned.PwnedPasswords.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Functions/Functions/Range.cs
+++ b/Functions/Functions/Range.cs
@@ -1,4 +1,7 @@
-﻿namespace HaveIBeenPwned.PwnedPasswords.Functions;
+﻿
+using Microsoft.Net.Http.Headers;
+
+namespace HaveIBeenPwned.PwnedPasswords.Functions;
 
 /// <summary>
 /// Main entry point for Pwned Passwords
@@ -46,7 +49,7 @@ public class Range
         try
         {
             PwnedPasswordsFile entry = await _fileStorage.GetHashFileAsync(hashPrefix.ToUpper(), mode, cancellationToken);
-            return new FileStreamResult(entry.Content, "text/plain") { LastModified = entry.LastModified };
+            return new FileStreamResult(entry.Content, "text/plain") { LastModified = entry.LastModified, EntityTag = new EntityTagHeaderValue(entry.ETag, false) };
         }
         catch (FileNotFoundException)
         {

--- a/Functions/HaveIBeenPwned.PwnedPasswords.csproj
+++ b/Functions/HaveIBeenPwned.PwnedPasswords.csproj
@@ -12,29 +12,29 @@
     <Using Include="System.IO" />
     <Using Include="System.Text" />
     <Using Include="System.Text.Json" />
-    <Using Include="System.Threading"/>
-    <Using Include="System.Threading.Tasks"/>
+    <Using Include="System.Threading" />
+    <Using Include="System.Threading.Tasks" />
     <Using Include="Azure" />
     <Using Include="Azure.Data.Tables" />
     <Using Include="Azure.Storage.Queues" />
-    <Using Include="Microsoft.AspNetCore.Http"/>
-    <Using Include="Microsoft.AspNetCore.Mvc"/>
-    <Using Include="Microsoft.Azure.WebJobs"/>
-    <Using Include="Microsoft.Azure.WebJobs.Extensions.Http"/>
-    <Using Include="Microsoft.Extensions.Configuration"/>
-    <Using Include="Microsoft.Extensions.DependencyInjection"/>
-    <Using Include="Microsoft.Extensions.Logging"/>
-    <Using Include="Microsoft.Extensions.Options"/>
-    <Using Include="HaveIBeenPwned.PwnedPasswords.Abstractions"/>
-    <Using Include="HaveIBeenPwned.PwnedPasswords.Models"/>
+    <Using Include="Microsoft.AspNetCore.Http" />
+    <Using Include="Microsoft.AspNetCore.Mvc" />
+    <Using Include="Microsoft.Azure.WebJobs" />
+    <Using Include="Microsoft.Azure.WebJobs.Extensions.Http" />
+    <Using Include="Microsoft.Extensions.Configuration" />
+    <Using Include="Microsoft.Extensions.DependencyInjection" />
+    <Using Include="Microsoft.Extensions.Logging" />
+    <Using Include="Microsoft.Extensions.Options" />
+    <Using Include="HaveIBeenPwned.PwnedPasswords.Abstractions" />
+    <Using Include="HaveIBeenPwned.PwnedPasswords.Models" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ApplicationInsights" Version="1.0.0-preview4" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
-    <PackageReference Include="Azure.Data.Tables" Version="12.7.1" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\HaveIBeenPwned.PwnedPasswords.Shared\HaveIBeenPwned.PwnedPasswords.Shared.csproj" />

--- a/Shared/HaveIBeenPwned.PwnedPasswords.Shared/HaveIBeenPwned.PwnedPasswords.Shared.csproj
+++ b/Shared/HaveIBeenPwned.PwnedPasswords.Shared/HaveIBeenPwned.PwnedPasswords.Shared.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.1" />
     <PackageReference Include="System.IO.Pipelines" Version="7.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

Adding ETag to the response headers. This allows clients to only fetch the entire body content  when it has actually changed.
Also updating a few NuGet packages.

## Checklist:
<!-- Please replace every instance of `[ ]` with `[X]` to indicate you have completed the criteria -->

- [X] I confirm that my submission adheres to the [Code of Conduct](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/CODE_OF_CONDUCT.md).
- [X] I have tested that the code works with sample data and verified all tests are passing
- [X] I have verified that any tests that I have supplied with this Pull Request work and I have fixed any code which caused pre-existing tests to fail.
- [X] I have updated the [README](https://github.com/HaveIBeenPwned/PwnedPasswordsAzureFunction/blob/main/README.md) with any changes in dependencies/configuration values.
- [X] I have linted my code to ensure that it is formatted correctly.

<!-- Thank you for your submission and for contributing to Have I Been Pwned's Pwned Passwords! -->
