### PR TITLE
fix: correct typos in error messages and method name

### DIFF
--- a/Functions/HttpRequestDataExtensions.cs
+++ b/Functions/HttpRequestDataExtensions.cs
@@ -83,7 +83,7 @@ internal static class HttpRequestDataExtensions
             if (!entry.NTLMHash.IsStringNTLMHash())
             {
                 // Invalid NTLM hash, bad request
-                return (false, req.BadRequest("The NTLM has was not in a valid format at index " + i));
+                return (false, req.BadRequest("The NTLM hash was not in a valid format at index " + i));
             }
 
             if (entry.Prevalence <= 0)

--- a/Functions/Implementations/Azure/TableStorage.cs
+++ b/Functions/Implementations/Azure/TableStorage.cs
@@ -61,7 +61,7 @@ public sealed class TableStorage : ITableStorage
         }
         catch (RequestFailedException e) when (e.Status == StatusCodes.Status409Conflict)
         {
-            throw new ArgumentException("Transaciton has already been updated.", e);
+            throw new ArgumentException("Transaction has already been updated.", e);
         }
         catch (RequestFailedException e)
         {

--- a/Tools/PwnedPasswords-IngestionPatcher/Program.cs
+++ b/Tools/PwnedPasswords-IngestionPatcher/Program.cs
@@ -45,9 +45,9 @@ foreach (string ingestionFile in Directory.EnumerateFiles($@"**REPLACE WITH INPU
 }
 
 int num = 0;
-await Parallel.ForEachAsync(entries, WriteEnties);
+await Parallel.ForEachAsync(entries, WriteEntries);
 
-async ValueTask WriteEnties(KeyValuePair<string, List<HashEntry>> entry, CancellationToken cancellationToken)
+async ValueTask WriteEntries(KeyValuePair<string, List<HashEntry>> entry, CancellationToken cancellationToken)
 {
     await ParseAndUpdateHashFile(entry.Key, entry.Value, false).ConfigureAwait(false);
     entries.Remove(entry.Key);


### PR DESCRIPTION
## Summary

Fix 4 typos across 3 files:

- `TableStorage.cs`: `Transaciton` → `Transaction` (error message)
- `HttpRequestDataExtensions.cs`: `NTLM has` → `NTLM hash` (error message)
- `Program.cs`: `WriteEnties` → `WriteEntries` (method declaration and call site)

**Note:** The `WriteEnties` → `WriteEntries` rename is a functional change (method rename). Both the declaration and single call site are in the same file, so no external callers are affected.